### PR TITLE
Add end-to-end tests for Pinggy CLI functionality

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -9,7 +9,7 @@ jobs:
   e2e:
     name: E2E on ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     defaults:
       run:
@@ -69,165 +69,12 @@ jobs:
 
       - name: Verify binary exists (Unix)
         if: runner.os != 'Windows'
-        run: ls -lh ${{ matrix.binary }}
+        run: ls -lh ${{ matrix.binary }} && chmod +x ${{ matrix.binary }}
 
       - name: Verify binary exists (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: Get-Item "${{ matrix.binary }}" | Select-Object Name, Length, LastWriteTime
 
-      - name: Create test content (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          mkdir -p test-site
-          echo '<html><body><h1>Pinggy E2E Test</h1></body></html>' > test-site/index.html
-
-      - name: Create test content (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path test-site | Out-Null
-          Set-Content -Path test-site/index.html -Value '<html><body><h1>Pinggy E2E Test</h1></body></html>'
-
-      - name: Start tunnel and verify (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          set -euo pipefail
-
-          DEBUGGER_PORT=4300
-
-          chmod +x ${{ matrix.binary }} || true
-
-          ${{ matrix.binary }} --serve ./test-site --noTui -d $DEBUGGER_PORT > tunnel.log 2>&1 &
-          CLI_PID=$!
-          echo "Started CLI with PID $CLI_PID"
-
-          trap "echo 'Cleaning up CLI process $CLI_PID'; kill $CLI_PID 2>/dev/null || true; wait $CLI_PID 2>/dev/null || true" EXIT SIGINT SIGTERM
-
-          TUNNEL_URL=""
-          for i in $(seq 1 15); do
-            URLS_JSON=$(curl -s --max-time 5 "http://localhost:$DEBUGGER_PORT/urls" 2>/dev/null || true)
-
-            if [ -n "$URLS_JSON" ]; then
-              echo "Got /urls response:"
-              echo "$URLS_JSON" | jq . || echo "$URLS_JSON"
-
-              TUNNEL_URL=$(echo "$URLS_JSON" | jq -r '.urls[] | select(startswith("https://"))' | head -1)
-
-              if [ -n "$TUNNEL_URL" ] && [ "$TUNNEL_URL" != "null" ]; then
-                echo "Found tunnel URL: $TUNNEL_URL"
-                break
-              fi
-            fi
-
-            echo "Waiting for tunnel URL via debugger... (attempt $i/15)"
-            sleep 2
-          done
-
-          if [ -z "$TUNNEL_URL" ]; then
-            echo "ERROR: Failed to get tunnel URL within timeout"
-            echo "=== tunnel.log ==="
-            cat tunnel.log || true
-            exit 1
-          fi
-
-          sleep 3
-
-          echo "Fetching $TUNNEL_URL ..."
-          HTTP_STATUS=$(curl -s -o response.html -w "%{http_code}" --max-time 30 "$TUNNEL_URL" || true)
-          echo "HTTP status: $HTTP_STATUS"
-
-          echo "=== Response body ==="
-          cat response.html || true
-          echo ""
-
-          if [ "$HTTP_STATUS" -ne 200 ]; then
-            echo "ERROR: Expected HTTP 200, got $HTTP_STATUS"
-            echo "=== tunnel.log ==="
-            cat tunnel.log || true
-            exit 1
-          fi
-
-          if grep -q "Pinggy E2E Test" response.html; then
-            echo "SUCCESS: Tunnel is serving the expected content"
-          else
-            echo "ERROR: Response does not contain expected content"
-            exit 1
-          fi
-
-          echo "=== tunnel.log ==="
-          cat tunnel.log || true
-          echo ""
-          echo "E2E test passed!"
-
-      - name: Start tunnel and verify (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $DEBUGGER_PORT = 4300
-
-          $proc = Start-Process -FilePath "${{ matrix.binary }}" `
-            -ArgumentList @("--serve", "./test-site", "--noTui", "-d", $DEBUGGER_PORT) `
-            -NoNewWindow -PassThru `
-            -RedirectStandardOutput "tunnel.log" `
-            -RedirectStandardError "tunnel-err.log"
-          Write-Host "Started CLI with PID $($proc.Id)"
-
-          try {
-            $tunnelUrl = $null
-            for ($i = 1; $i -le 15; $i++) {
-              Start-Sleep -Seconds 2
-              try {
-                $resp = Invoke-RestMethod -Uri "http://localhost:$DEBUGGER_PORT/urls" -TimeoutSec 5 -ErrorAction Stop
-                Write-Host "Got /urls response:"
-                $resp | ConvertTo-Json | Write-Host
-                $tunnelUrl = $resp.urls | Where-Object { $_ -like 'https://*' } | Select-Object -First 1
-                if ($tunnelUrl) {
-                  Write-Host "Found tunnel URL: $tunnelUrl"
-                  break
-                }
-              } catch {
-                Write-Host "Waiting for tunnel URL via debugger... (attempt $i/15)"
-              }
-            }
-
-            if (-not $tunnelUrl) {
-              Write-Host "ERROR: Failed to get tunnel URL within timeout"
-              Write-Host "=== tunnel.log ==="
-              Get-Content tunnel.log, tunnel-err.log -ErrorAction SilentlyContinue
-              exit 1
-            }
-
-            Start-Sleep -Seconds 3
-
-            Write-Host "Fetching $tunnelUrl ..."
-            $httpStatus = & curl.exe -s -o response.html -w "%{http_code}" --max-time 30 $tunnelUrl 2>&1
-            $body = Get-Content response.html -Raw -ErrorAction SilentlyContinue
-
-            Write-Host "HTTP status: $httpStatus"
-            Write-Host "=== Response body ==="
-            Write-Host $body
-
-            if ($httpStatus -ne "200") {
-              Write-Host "ERROR: Expected HTTP 200, got $httpStatus"
-              Write-Host "=== tunnel.log ==="
-              Get-Content tunnel.log -ErrorAction SilentlyContinue
-              exit 1
-            }
-
-            if ($body -match 'Pinggy E2E Test') {
-              Write-Host "SUCCESS: Tunnel is serving the expected content"
-            } else {
-              Write-Host "ERROR: Response does not contain expected content"
-              exit 1
-            }
-
-            Write-Host "=== tunnel.log ==="
-            Get-Content tunnel.log -ErrorAction SilentlyContinue
-            Write-Host "E2E test passed!"
-
-          } finally {
-            Write-Host "Cleaning up CLI process $($proc.Id)"
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
-          }
+      - name: Run E2E suite
+        run: node test/e2e/run.cjs ${{ matrix.binary }}

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ lib/
 logs/
 src/
 node_modules/
+test/
 
 
 index-test.js

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,112 @@
+# Pinggy CLI E2E Tests
+
+End-to-end tests that exercise the packaged `pkg` binary against real Pinggy free-tier tunnels. Each case spawns the CLI, waits for the tunnel to come up, then asserts behavior over the live HTTPS / TCP / UDP endpoint.
+
+## Run
+
+```bash
+node test/e2e/run.cjs <path-to-binary>
+```
+
+Examples:
+
+```bash
+node test/e2e/run.cjs out/pinggy-macos-arm64
+node test/e2e/run.cjs out/pinggy-linux-x64
+```
+
+The runner exits non-zero on the first failure. A summary is printed at the end.
+
+CI runs the same command across 6 platforms in `.github/workflows/e2e-test.yml`.
+
+## What gets tested
+
+| Case | Verifies |
+|---|---|
+| `serve` | `--serve <dir>` static file mode returns the expected HTML over the tunnel |
+| `headers` | `a:` adds, `u:` updates, `r:` removes request headers. `x:xff` reaches the SDK config |
+| `basic-auth` | `b:user:pass` returns 401 for no/wrong creds and 200 for correct |
+| `bearer-auth` | `k:TOKEN` returns 401 without bearer and 200 with `Authorization: Bearer TOKEN` |
+| `whitelist-allow` | `w:<runner-ip>/32` allows the runner. IP is parsed from the previous tunnel URL |
+| `whitelist-deny` | `w:10.0.0.1/32` blocks the runner. Connection-level rejection accepted as denial |
+| `https-only` | `x:https` rejects HTTP and serves HTTPS |
+| `tcp` | `tcp@free.pinggy.io` exposes a real `tcp://host:port`. Echo roundtrip succeeds |
+| `udp` | `udp@free.pinggy.io` exposes a real `udp://host:port`. Echo roundtrip succeeds |
+| `config-roundtrip` | `--saveconf` writes a file. A second run with `--conf` works |
+| `debugger-ws` | `/introspec/websocket` emits a `{req, res}` frame for a tunneled request |
+
+## debugger-ws in detail
+
+The web debugger (configured with `-L<port>:localhost:<port>`) exposes two endpoints on that local port:
+
+- `GET /urls` — JSON list of active tunnel URLs
+- `WS /introspec/websocket` — a stream that pushes one JSON frame per request/response pair flowing through the tunnel
+
+The first is used elsewhere in the suite as a fallback liveness signal. This case is the only one that exercises the second. The TUI subscribes to the same WebSocket to render its live request log, so a regression here would ship a CLI whose tunnels work but whose TUI never updates.
+
+The case:
+
+1. Starts an HTTP echo backend.
+2. Spawns the CLI with a normal HTTP tunnel and `-L<port>:localhost:<port>`.
+3. Opens a WebSocket to `ws://<host>:<port>/introspec/websocket`. Tries `localhost`, `127.0.0.1`, `[::1]` in turn so the test does not care which loopback the SDK happens to bind.
+4. Makes one HTTPS request through the tunnel.
+5. Polls the WebSocket message buffer for up to 15 s waiting for a frame where `f.req || f.res` is truthy.
+6. Fails with a diagnostic dump of received frames if nothing matching arrives.
+
+The frame schema (`{req: {key, method, uri}, res: {key, status}}`, defined in `src/tui/blessed/webDebuggerConnection.ts`) is matched loosely. The test asserts that *some* recognisable frame arrives rather than pinning every field, so harmless schema additions do not break it.
+
+## Layout
+
+```
+test/e2e/
+  run.cjs                  # entry: arg parsing, case registry, main loop
+  echo-http.cjs            # HTTP backend that echoes request as JSON
+  echo-tcp.cjs             # raw TCP echo backend
+  echo-udp.cjs             # UDP datagram echo backend
+  lib/
+    cli.cjs                # process lifecycle, log/URL tunnel detection
+    framework.cjs          # state, runCase, withTunnel, withEcho, buildArgs, helpers
+  cases/<case-name>.cjs    # one file per test case
+```
+
+The `lib/cli.cjs` module spawns the binary, watches the log file for `Tunnel started {...,"urls":[...]}`, and falls back to `/urls` polling. Cross-platform process termination uses `taskkill /T /F` on Windows and `SIGTERM` then `SIGKILL` on Unix.
+
+The `lib/framework.cjs` module owns shared state (workdir, debugger-port counter, public IP parsed from URL) and exports the helpers cases compose:
+
+- `withTunnel({ name, build }, fn)` spawns the CLI with `buildArgs(build)`, waits for URLs, calls `fn({ urls, dbg, log })`, kills the process on exit.
+- `withEcho(kind, fn)` starts an HTTP / TCP / UDP echo backend, calls `fn(echo)`, stops the backend.
+- `buildArgs({...})` constructs SSH-style invocations: `-R0:localhost:<port> -L<dbg>:localhost:<dbg> [type@]free.pinggy.io [extOpts...]`.
+- `SkipCase` is an `Error` subclass. Throwing it from a case marks the case `SKIP` instead of `FAIL`.
+
+## Add a new case
+
+1. Create `cases/<name>.cjs`:
+
+```js
+const { withTunnel, withEcho, pickHttpsUrl } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: '<name>',
+  async run() {
+    await withEcho('http', (echo) =>
+      withTunnel(
+        { name: '<name>', build: { localPort: echo.port, extOpts: ['<flag>'] } },
+        async ({ urls }) => {
+          const url = pickHttpsUrl(urls);
+          // assertions...
+        }
+      )
+    );
+  },
+};
+```
+
+2. Register it in `run.cjs`:
+
+```js
+const cases = [
+  // ...
+  require('./cases/<name>.cjs'),
+];
+```
+

--- a/test/e2e/cases/basic-auth.cjs
+++ b/test/e2e/cases/basic-auth.cjs
@@ -1,0 +1,30 @@
+const { withTunnel, withEcho, pickHttpsUrl } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'basic-auth',
+  async run() {
+    await withEcho('http', (echo) =>
+      withTunnel(
+        { name: 'basic-auth', build: { localPort: echo.port, extOpts: ['b:alice:s3cret'] } },
+        async ({ urls }) => {
+          const url = pickHttpsUrl(urls);
+
+          const noCreds = await fetch(url, { signal: AbortSignal.timeout(30000) });
+          if (noCreds.status !== 401) throw new Error(`without creds expected 401, got ${noCreds.status}`);
+
+          const wrong = await fetch(url, {
+            headers: { Authorization: 'Basic ' + Buffer.from('alice:wrong').toString('base64') },
+            signal: AbortSignal.timeout(30000),
+          });
+          if (wrong.status !== 401) throw new Error(`wrong creds expected 401, got ${wrong.status}`);
+
+          const right = await fetch(url, {
+            headers: { Authorization: 'Basic ' + Buffer.from('alice:s3cret').toString('base64') },
+            signal: AbortSignal.timeout(30000),
+          });
+          if (right.status !== 200) throw new Error(`correct creds expected 200, got ${right.status}`);
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/bearer-auth.cjs
+++ b/test/e2e/cases/bearer-auth.cjs
@@ -1,0 +1,24 @@
+const { withTunnel, withEcho, pickHttpsUrl } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'bearer-auth',
+  async run() {
+    await withEcho('http', (echo) =>
+      withTunnel(
+        { name: 'bearer-auth', build: { localPort: echo.port, extOpts: ['k:tk_test_abc123'] } },
+        async ({ urls }) => {
+          const url = pickHttpsUrl(urls);
+
+          const noHdr = await fetch(url, { signal: AbortSignal.timeout(30000) });
+          if (noHdr.status !== 401) throw new Error(`without bearer expected 401, got ${noHdr.status}`);
+
+          const good = await fetch(url, {
+            headers: { Authorization: 'Bearer tk_test_abc123' },
+            signal: AbortSignal.timeout(30000),
+          });
+          if (good.status !== 200) throw new Error(`with bearer expected 200, got ${good.status}`);
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/config-roundtrip.cjs
+++ b/test/e2e/cases/config-roundtrip.cjs
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const { withTunnel, withEcho, pickHttpsUrl, workDir } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'config-roundtrip',
+  async run() {
+    const cfgPath = path.join(workDir, 'tunnel-cfg.json');
+    await withEcho('http', async (echo) => {
+      await withTunnel(
+        { name: 'saveconf', build: { localPort: echo.port, extraFlags: ['--saveconf', cfgPath] } },
+        async ({ urls }) => {
+          const url = pickHttpsUrl(urls);
+          const res = await fetch(url, { signal: AbortSignal.timeout(30000) });
+          if (res.status !== 200) throw new Error(`saveconf run: expected 200, got ${res.status}`);
+          if (!fs.existsSync(cfgPath)) throw new Error('config file not written');
+          const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+          if (!cfg || typeof cfg !== 'object') throw new Error('config file empty');
+        }
+      );
+
+      await withTunnel(
+        { name: 'loadconf', build: { confFile: cfgPath, omitServer: true } },
+        async ({ urls }) => {
+          const url = pickHttpsUrl(urls);
+          const res = await fetch(url, { signal: AbortSignal.timeout(30000) });
+          if (res.status !== 200) throw new Error(`loadconf run: expected 200, got ${res.status}`);
+        }
+      );
+    });
+  },
+};

--- a/test/e2e/cases/debugger-ws.cjs
+++ b/test/e2e/cases/debugger-ws.cjs
@@ -1,0 +1,53 @@
+const { withTunnel, withEcho, pickHttpsUrl, sleep } = require('../lib/framework.cjs');
+
+async function connectWs(dbg) {
+  let openErr = null;
+  for (const host of ['localhost', '127.0.0.1', '[::1]']) {
+    try {
+      const candidate = new WebSocket(`ws://${host}:${dbg}/introspec/websocket`);
+      await new Promise((resolve, reject) => {
+        candidate.addEventListener('open', resolve, { once: true });
+        candidate.addEventListener('error', (e) => reject(new Error(e.message || 'connect failed')), { once: true });
+        setTimeout(() => reject(new Error('open timeout')), 5000);
+      });
+      return candidate;
+    } catch (e) {
+      openErr = e;
+    }
+  }
+  throw new Error(`could not connect to debugger ws: ${openErr && openErr.message}`);
+}
+
+module.exports = {
+  name: 'debugger-ws',
+  async run() {
+    await withEcho('http', (echo) =>
+      withTunnel(
+        { name: 'debugger-ws', build: { localPort: echo.port } },
+        async ({ urls, dbg }) => {
+          const url = pickHttpsUrl(urls);
+          const ws = await connectWs(dbg);
+          const frames = [];
+          ws.addEventListener('message', (ev) => {
+            try { frames.push(JSON.parse(ev.data.toString())); } catch {}
+          });
+
+          await fetch(url, {
+            headers: { 'X-WS-Probe': 'yes' },
+            signal: AbortSignal.timeout(30000),
+          });
+
+          const deadline = Date.now() + 15000;
+          while (Date.now() < deadline) {
+            if (frames.some((f) => f && (f.req || f.res))) break;
+            await sleep(500);
+          }
+          ws.close();
+          if (!frames.some((f) => f && (f.req || f.res))) {
+            throw new Error(`no req/res frame received; frames: ${JSON.stringify(frames).slice(0, 500)}`);
+          }
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/headers.cjs
+++ b/test/e2e/cases/headers.cjs
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const { withTunnel, withEcho, pickHttpsUrl, fetchJson } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'headers',
+  async run() {
+    await withEcho('http', (echo) =>
+      withTunnel(
+        {
+          name: 'headers',
+          build: {
+            localPort: echo.port,
+            extOpts: [
+              'a:X-E2E-Add:hello',
+              'u:User-Agent:e2e-runner',
+              'r:Cookie',
+              'x:xff',
+            ],
+          },
+        },
+        async ({ urls, log }) => {
+          const url = pickHttpsUrl(urls);
+          const { status, json } = await fetchJson(url, {
+            headers: {
+              'User-Agent': 'original-ua',
+              'Cookie': 'should-be-removed=1',
+              'X-Keep-Me': 'still-here',
+            },
+          });
+          if (status !== 200) throw new Error(`expected 200, got ${status}`);
+          if (!json) throw new Error('echo did not return JSON');
+          const h = json.headers || {};
+          const hDump = () => `received headers: ${JSON.stringify(h)}`;
+          if (h['x-e2e-add'] !== 'hello') throw new Error(`x-e2e-add missing/wrong: ${h['x-e2e-add']}. ${hDump()}`);
+          if (h['user-agent'] !== 'e2e-runner') throw new Error(`user-agent not updated: ${h['user-agent']}. ${hDump()}`);
+          if (h['cookie']) throw new Error(`cookie should have been removed, got: ${h['cookie']}. ${hDump()}`);
+          if (h['x-keep-me'] !== 'still-here') throw new Error(`passthrough header lost. ${hDump()}`);
+          // x:xff: free-tier Pinggy may not inject the header on the wire, but CLI must
+          // pass the option to the SDK. Verify via worker log.
+          const logContent = fs.readFileSync(log, 'utf-8');
+          if (!/X-Forwarded-For configuration set to:\s*true/i.test(logContent)) {
+            throw new Error('CLI did not propagate x:xff to the SDK');
+          }
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/https-only.cjs
+++ b/test/e2e/cases/https-only.cjs
@@ -1,0 +1,30 @@
+const { withTunnel, withEcho, pickHttpsUrl, pickHttpUrl } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'https-only',
+  async run() {
+    await withEcho('http', (echo) =>
+      withTunnel(
+        { name: 'https-only', build: { localPort: echo.port, extOpts: ['x:https'] } },
+        async ({ urls }) => {
+          const httpsUrl = pickHttpsUrl(urls);
+          const httpUrl = pickHttpUrl(urls);
+          if (!httpUrl) throw new Error('no http url to test against');
+
+          const httpRes = await fetch(httpUrl, {
+            redirect: 'manual',
+            signal: AbortSignal.timeout(30000),
+          });
+          if (httpRes.status === 200) {
+            throw new Error('http url returned 200, expected redirect/reject under x:https');
+          }
+
+          const httpsRes = await fetch(httpsUrl, { signal: AbortSignal.timeout(30000) });
+          if (httpsRes.status !== 200) {
+            throw new Error(`https url expected 200, got ${httpsRes.status}`);
+          }
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/serve.cjs
+++ b/test/e2e/cases/serve.cjs
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { withTunnel, pickHttpsUrl, workDir } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'serve',
+  async run() {
+    const siteDir = path.join(workDir, 'site');
+    fs.mkdirSync(siteDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(siteDir, 'index.html'),
+      '<html><body><h1>Pinggy E2E Test</h1></body></html>'
+    );
+
+    await withTunnel(
+      { name: 'serve', build: { serve: siteDir } },
+      async ({ urls }) => {
+        const url = pickHttpsUrl(urls);
+        if (!url) throw new Error('no HTTPS url returned');
+        const res = await fetch(url, { signal: AbortSignal.timeout(30000) });
+        if (res.status !== 200) throw new Error(`expected 200, got ${res.status}`);
+        const body = await res.text();
+        if (!body.includes('Pinggy E2E Test')) throw new Error('body missing expected content');
+      }
+    );
+  },
+};

--- a/test/e2e/cases/tcp.cjs
+++ b/test/e2e/cases/tcp.cjs
@@ -1,0 +1,43 @@
+const net = require('net');
+const { withTunnel, withEcho, pickProtoUrl, SkipCase } = require('../lib/framework.cjs');
+
+function tcpEcho(host, port, payload) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host, port, timeout: 15000 });
+    const chunks = [];
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error('tcp echo timeout'));
+    }, 15000);
+    socket.on('connect', () => socket.write(payload));
+    socket.on('data', (d) => {
+      chunks.push(d);
+      const got = Buffer.concat(chunks);
+      if (got.length >= payload.length) {
+        clearTimeout(timer);
+        socket.end();
+        if (got.equals(payload)) resolve();
+        else reject(new Error(`tcp echo mismatch: sent ${payload.toString()}, got ${got.toString()}`));
+      }
+    });
+    socket.on('error', (e) => { clearTimeout(timer); reject(e); });
+  });
+}
+
+module.exports = {
+  name: 'tcp',
+  async run() {
+    await withEcho('tcp', (echo) =>
+      withTunnel(
+        { name: 'tcp', build: { type: 'tcp', localPort: echo.port } },
+        async ({ urls }) => {
+          const tcpUrl = pickProtoUrl(urls, 'tcp');
+          if (!tcpUrl) throw new SkipCase(`no tcp:// url ; got ${urls.join(',')}`);
+          const u = new URL(tcpUrl);
+          if (!u.port) throw new SkipCase(`tcp url has no port: ${tcpUrl}`);
+          await tcpEcho(u.hostname, parseInt(u.port, 10), Buffer.from('hello-tcp-e2e'));
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/udp.cjs
+++ b/test/e2e/cases/udp.cjs
@@ -1,0 +1,40 @@
+const dgram = require('dgram');
+const { withTunnel, withEcho, pickProtoUrl, SkipCase } = require('../lib/framework.cjs');
+
+function udpEcho(host, port, payload) {
+  return new Promise((resolve, reject) => {
+    const sock = dgram.createSocket('udp4');
+    const timer = setTimeout(() => {
+      sock.close();
+      reject(new Error('udp echo timeout'));
+    }, 15000);
+    sock.on('message', (msg) => {
+      clearTimeout(timer);
+      sock.close();
+      if (msg.equals(payload)) resolve();
+      else reject(new Error(`udp echo mismatch: sent ${payload.toString()}, got ${msg.toString()}`));
+    });
+    sock.on('error', (e) => { clearTimeout(timer); reject(e); });
+    sock.send(payload, port, host, (err) => {
+      if (err) { clearTimeout(timer); sock.close(); reject(err); }
+    });
+  });
+}
+
+module.exports = {
+  name: 'udp',
+  async run() {
+    await withEcho('udp', (echo) =>
+      withTunnel(
+        { name: 'udp', build: { type: 'udp', localPort: echo.port } },
+        async ({ urls }) => {
+          const udpUrl = pickProtoUrl(urls, 'udp');
+          if (!udpUrl) throw new SkipCase(`no udp:// url; got ${urls.join(',')}`);
+          const u = new URL(udpUrl);
+          if (!u.port) throw new SkipCase(`udp url has no port: ${udpUrl}`);
+          await udpEcho(u.hostname, parseInt(u.port, 10), Buffer.from('hello-udp-e2e'));
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/whitelist-allow.cjs
+++ b/test/e2e/cases/whitelist-allow.cjs
@@ -1,0 +1,21 @@
+const { withTunnel, withEcho, pickHttpsUrl, getPublicIp, SkipCase } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'whitelist-allow',
+  async run() {
+    const ip = getPublicIp();
+    if (!ip) throw new SkipCase('public IP not yet parsed from a tunnel URL');
+    const cidr = `${ip}/32`;
+    await withEcho('http', (echo) =>
+      withTunnel(
+        { name: 'whitelist-allow', build: { localPort: echo.port, extOpts: [`w:${cidr}`] } },
+        async ({ urls }) => {
+          process.stdout.write(`  whitelist: ${cidr}\n`);
+          const url = pickHttpsUrl(urls);
+          const res = await fetch(url, { signal: AbortSignal.timeout(30000) });
+          if (res.status !== 200) throw new Error(`expected 200 for whitelist ${cidr}, got ${res.status}`);
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/whitelist-deny.cjs
+++ b/test/e2e/cases/whitelist-deny.cjs
@@ -1,0 +1,24 @@
+const { withTunnel, withEcho, pickHttpsUrl } = require('../lib/framework.cjs');
+
+module.exports = {
+  name: 'whitelist-deny',
+  async run() {
+    await withEcho('http', (echo) =>
+      withTunnel(
+        { name: 'whitelist-deny', build: { localPort: echo.port, extOpts: ['w:10.0.0.1/32'] } },
+        async ({ urls }) => {
+          const url = pickHttpsUrl(urls);
+          let status = null;
+          try {
+            const res = await fetch(url, { signal: AbortSignal.timeout(30000) });
+            status = res.status;
+          } catch {
+            // connection-level rejection is also a valid form of denial
+            return;
+          }
+          if (status === 200) throw new Error('expected denial, got 200');
+        }
+      )
+    );
+  },
+};

--- a/test/e2e/cases/whitelist-deny.cjs
+++ b/test/e2e/cases/whitelist-deny.cjs
@@ -1,5 +1,32 @@
 const { withTunnel, withEcho, pickHttpsUrl } = require('../lib/framework.cjs');
 
+const CONNECTION_RESET_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+]);
+
+function findResetCode(err) {
+  let cur = err;
+  while (cur) {
+    if (cur.code && CONNECTION_RESET_CODES.has(cur.code)) return cur.code;
+    cur = cur.cause;
+  }
+  return null;
+}
+
+function describeError(err) {
+  const parts = [];
+  let cur = err;
+  while (cur) {
+    parts.push(`${cur.name || 'Error'}${cur.code ? `(${cur.code})` : ''}: ${cur.message}`);
+    cur = cur.cause;
+  }
+  return parts.join(' <- ');
+}
+
 module.exports = {
   name: 'whitelist-deny',
   async run() {
@@ -8,15 +35,25 @@ module.exports = {
         { name: 'whitelist-deny', build: { localPort: echo.port, extOpts: ['w:10.0.0.1/32'] } },
         async ({ urls }) => {
           const url = pickHttpsUrl(urls);
-          let status = null;
+
+          let res;
           try {
-            const res = await fetch(url, { signal: AbortSignal.timeout(30000) });
-            status = res.status;
-          } catch {
-            // connection-level rejection is also a valid form of denial
+            res = await fetch(url, { signal: AbortSignal.timeout(30000) });
+          } catch (err) {
+            const code = findResetCode(err);
+            if (code) {
+              process.stdout.write(`  denial: connection reset (${code})\n`);
+              return;
+            }
+            throw new Error(`whitelist deny expected 403 or connection reset; got error: ${describeError(err)}`);
+          }
+
+          // Edge returned an HTTP response. Only 403 counts as a legitimate denial.
+          if (res.status === 403) {
+            process.stdout.write(`  denial: HTTP 403\n`);
             return;
           }
-          if (status === 200) throw new Error('expected denial, got 200');
+          throw new Error(`whitelist deny expected status 403 or connection reset; got ${res.status}`);
         }
       )
     );

--- a/test/e2e/echo-http.cjs
+++ b/test/e2e/echo-http.cjs
@@ -1,0 +1,28 @@
+const http = require('http');
+
+const port = parseInt(process.argv[2] || '0', 10);
+
+const server = http.createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (c) => chunks.push(c));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString('utf-8');
+    const payload = {
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body,
+      remoteAddr: req.socket.remoteAddress,
+    };
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(payload));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  const addr = server.address();
+  process.stdout.write(`LISTENING ${addr.port}\n`);
+});
+
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+process.on('SIGINT', () => server.close(() => process.exit(0)));

--- a/test/e2e/echo-tcp.cjs
+++ b/test/e2e/echo-tcp.cjs
@@ -1,0 +1,18 @@
+const net = require('net');
+
+const port = parseInt(process.argv[2] || '0', 10);
+
+const server = net.createServer((socket) => {
+  socket.on('data', (data) => {
+    socket.write(data);
+  });
+  socket.on('error', () => {});
+});
+
+server.listen(port, '127.0.0.1', () => {
+  const addr = server.address();
+  process.stdout.write(`LISTENING ${addr.port}\n`);
+});
+
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+process.on('SIGINT', () => server.close(() => process.exit(0)));

--- a/test/e2e/echo-udp.cjs
+++ b/test/e2e/echo-udp.cjs
@@ -1,0 +1,19 @@
+const dgram = require('dgram');
+
+const port = parseInt(process.argv[2] || '0', 10);
+
+const server = dgram.createSocket('udp4');
+
+server.on('message', (msg, rinfo) => {
+  server.send(msg, rinfo.port, rinfo.address);
+});
+
+server.on('listening', () => {
+  const addr = server.address();
+  process.stdout.write(`LISTENING ${addr.port}\n`);
+});
+
+server.bind(port, '127.0.0.1');
+
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+process.on('SIGINT', () => server.close(() => process.exit(0)));

--- a/test/e2e/lib/cli.cjs
+++ b/test/e2e/lib/cli.cjs
@@ -1,0 +1,164 @@
+const { spawn, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const isWindows = process.platform === 'win32';
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function fetchUrls(debuggerPort) {
+  for (const host of ['127.0.0.1', 'localhost', '[::1]']) {
+    try {
+      const res = await fetch(`http://${host}:${debuggerPort}/urls`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (!res.ok) continue;
+      const data = await res.json();
+      if (data && Array.isArray(data.urls) && data.urls.length > 0) return data;
+    } catch {}
+  }
+  return null;
+}
+
+function extractUrlsFromLog(content) {
+  const lines = content.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    const idx = line.indexOf('Tunnel started ');
+    if (idx === -1) continue;
+    const jsonStart = line.indexOf('{', idx);
+    if (jsonStart === -1) continue;
+    try {
+      const obj = JSON.parse(line.slice(jsonStart));
+      if (obj && Array.isArray(obj.urls) && obj.urls.length > 0) return obj.urls;
+    } catch {}
+  }
+  return null;
+}
+
+function detectFatalErrorInLog(content) {
+  const errorPatterns = [
+    /Tunnel failed/i,
+    /Authentication failed/i,
+    /\[CLI\] \[error\]/,
+    /RemoteManagementUnauthorizedError/,
+    /unable to start tunnel/i,
+  ];
+  for (const re of errorPatterns) {
+    const m = content.match(re);
+    if (m) {
+      const lineStart = content.lastIndexOf('\n', m.index) + 1;
+      const lineEnd = content.indexOf('\n', m.index);
+      return content.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+    }
+  }
+  return null;
+}
+
+async function waitForTunnel({ logFile, debuggerPort }, { maxMs = 60000, pollMs = 500 } = {}) {
+  const deadline = Date.now() + maxMs;
+  let lastErr = null;
+
+  while (Date.now() < deadline) {
+    if (logFile && fs.existsSync(logFile)) {
+      const content = fs.readFileSync(logFile, 'utf-8');
+      const urls = extractUrlsFromLog(content);
+      if (urls) return urls;
+      lastErr = detectFatalErrorInLog(content);
+      if (lastErr) throw new Error(`CLI reported fatal error: ${lastErr.trim()}`);
+    }
+
+    if (debuggerPort) {
+      const data = await fetchUrls(debuggerPort);
+      if (data && Array.isArray(data.urls) && data.urls.length > 0) return data.urls;
+    }
+
+    await sleep(pollMs);
+  }
+  return null;
+}
+
+function killProc(proc) {
+  if (!proc || proc.killed || proc.exitCode !== null) return;
+  if (isWindows) {
+    try {
+      execSync(`taskkill /pid ${proc.pid} /T /F`, { stdio: 'ignore' });
+    } catch {}
+  } else {
+    try {
+      proc.kill('SIGTERM');
+    } catch {}
+    setTimeout(() => {
+      if (proc.exitCode === null && !proc.killed) {
+        try { proc.kill('SIGKILL'); } catch {}
+      }
+    }, 5000).unref();
+  }
+}
+
+function spawnCli(binary, args, { logFile, cwd } = {}) {
+  const out = logFile ? fs.openSync(logFile, 'w') : 'ignore';
+  const err = logFile ? fs.openSync(logFile + '.err', 'w') : 'ignore';
+  const proc = spawn(binary, args, {
+    stdio: ['ignore', out, err],
+    cwd: cwd || process.cwd(),
+    windowsHide: true,
+  });
+  return proc;
+}
+
+function dumpLogs(logFile) {
+  for (const suffix of ['', '.err']) {
+    const p = logFile + suffix;
+    if (fs.existsSync(p)) {
+      const content = fs.readFileSync(p, 'utf-8');
+      if (content.trim()) {
+        process.stdout.write(`--- ${path.basename(p)} ---\n${content}\n`);
+      }
+    }
+  }
+}
+
+async function startEchoServer(script, port = 0) {
+  const proc = spawn(process.execPath, [script, String(port)], {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    windowsHide: true,
+  });
+  const actualPort = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`echo server ${script} did not start in time`)), 10000);
+    let buf = '';
+    proc.stdout.on('data', (chunk) => {
+      buf += chunk.toString('utf-8');
+      const m = buf.match(/LISTENING (\d+)/);
+      if (m) {
+        clearTimeout(timer);
+        resolve(parseInt(m[1], 10));
+      }
+    });
+    proc.on('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`echo server ${script} exited early with code ${code}`));
+    });
+  });
+  return { proc, port: actualPort };
+}
+
+function stopEchoServer(echo) {
+  if (!echo || !echo.proc) return;
+  killProc(echo.proc);
+}
+
+module.exports = {
+  isWindows,
+  sleep,
+  fetchUrls,
+  waitForTunnel,
+  killProc,
+  spawnCli,
+  dumpLogs,
+  startEchoServer,
+  stopEchoServer,
+};

--- a/test/e2e/lib/framework.cjs
+++ b/test/e2e/lib/framework.cjs
@@ -1,0 +1,151 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const {
+  sleep,
+  waitForTunnel,
+  killProc,
+  spawnCli,
+  dumpLogs,
+  startEchoServer,
+  stopEchoServer,
+} = require('./cli.cjs');
+
+const SERVER = 'free.pinggy.io';
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pinggy-e2e-'));
+
+let dbgPortCounter = 4300;
+function nextDbgPort() { return dbgPortCounter++; }
+
+let binaryPath = null;
+function setBinary(p) { binaryPath = p; }
+
+const echoScripts = {
+  http: path.join(__dirname, '..', 'echo-http.cjs'),
+  tcp: path.join(__dirname, '..', 'echo-tcp.cjs'),
+  udp: path.join(__dirname, '..', 'echo-udp.cjs'),
+};
+
+let publicIp = null;
+function captureIp(urls) {
+  if (publicIp) return;
+  for (const u of urls) {
+    const m = u.match(/-(\d+-\d+-\d+-\d+)\.run\.pinggy-free\.link/);
+    if (m) { publicIp = m[1].replace(/-/g, '.'); return; }
+  }
+}
+function getPublicIp() { return publicIp; }
+
+const results = [];
+function getResults() { return results; }
+
+class SkipCase extends Error {
+  constructor(msg) { super(msg); this.skip = true; }
+}
+
+async function runCase(name, fn) {
+  const t0 = Date.now();
+  process.stdout.write(`\n>>> CASE ${name}\n`);
+  try {
+    await fn();
+    const dt = ((Date.now() - t0) / 1000).toFixed(1);
+    process.stdout.write(`<<< PASS ${name} (${dt}s)\n`);
+    results.push({ name, status: 'PASS' });
+  } catch (err) {
+    const dt = ((Date.now() - t0) / 1000).toFixed(1);
+    if (err && err.skip) {
+      process.stdout.write(`<<< SKIP ${name} (${dt}s): ${err.message}\n`);
+      results.push({ name, status: 'SKIP' });
+      return;
+    }
+    process.stdout.write(`<<< FAIL ${name} (${dt}s): ${err && err.message ? err.message : err}\n`);
+    results.push({ name, status: 'FAIL', err });
+    throw err;
+  }
+}
+
+function buildArgs({ type = 'http', localPort, dbg, serve, extOpts = [], extraFlags = [], confFile, omitServer = false }) {
+  const args = ['--noTui', '--vvv'];
+  if (serve) args.push('--serve', serve);
+  if (localPort != null) args.push(`-R0:localhost:${localPort}`);
+  args.push(`-L${dbg}:localhost:${dbg}`);
+  args.push(...extraFlags);
+  if (confFile) args.push('--conf', confFile);
+  if (!omitServer) args.push(type === 'http' ? SERVER : `${type}@${SERVER}`);
+  args.push(...extOpts);
+  return args;
+}
+
+function logFileFor(name) {
+  return path.join(workDir, `tunnel-${name}.log`);
+}
+
+async function withTunnel({ name, build }, fn) {
+  if (!binaryPath) throw new Error('binaryPath not set (call setBinary first)');
+  const dbg = nextDbgPort();
+  const log = logFileFor(name);
+  const fullArgs = buildArgs({ ...build, dbg });
+  process.stdout.write(`  args: ${fullArgs.join(' ')}\n`);
+  const proc = spawnCli(binaryPath, fullArgs, { logFile: log });
+  try {
+    const urls = await waitForTunnel({ logFile: log, debuggerPort: dbg });
+    if (!urls) {
+      dumpLogs(log);
+      throw new Error('tunnel did not come up within timeout');
+    }
+    process.stdout.write(`  urls: ${urls.join(', ')}\n`);
+    captureIp(urls);
+    await sleep(2000);
+    await fn({ urls, dbg, log });
+  } catch (err) {
+    dumpLogs(log);
+    throw err;
+  } finally {
+    killProc(proc);
+    await sleep(500);
+  }
+}
+
+async function withEcho(kind, fn) {
+  const echo = await startEchoServer(echoScripts[kind]);
+  try { return await fn(echo); } finally { stopEchoServer(echo); }
+}
+
+function pickHttpsUrl(urls) {
+  return urls.find((u) => u.startsWith('https://')) || urls.find((u) => u.startsWith('http://'));
+}
+function pickHttpUrl(urls) {
+  return urls.find((u) => u.startsWith('http://') && !u.startsWith('https://'));
+}
+function pickProtoUrl(urls, proto) {
+  return urls.find((u) => u.startsWith(proto + '://'));
+}
+
+async function fetchJson(url, opts = {}) {
+  const res = await fetch(url, {
+    redirect: 'manual',
+    signal: AbortSignal.timeout(30000),
+    ...opts,
+  });
+  const text = await res.text();
+  let json = null;
+  try { json = JSON.parse(text); } catch {}
+  return { status: res.status, headers: res.headers, text, json };
+}
+
+module.exports = {
+  SERVER,
+  workDir,
+  sleep,
+  setBinary,
+  getPublicIp,
+  SkipCase,
+  runCase,
+  getResults,
+  withTunnel,
+  withEcho,
+  pickHttpsUrl,
+  pickHttpUrl,
+  pickProtoUrl,
+  fetchJson,
+};

--- a/test/e2e/run.cjs
+++ b/test/e2e/run.cjs
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const { setBinary, runCase, getResults, workDir } = require('./lib/framework.cjs');
+
+const binary = process.argv[2];
+if (!binary) {
+  console.error('Usage: node run.cjs <path-to-pinggy-binary>');
+  process.exit(2);
+}
+const binaryPath = path.resolve(binary);
+if (!fs.existsSync(binaryPath)) {
+  console.error(`Binary not found: ${binaryPath}`);
+  process.exit(2);
+}
+setBinary(binaryPath);
+
+const cases = [
+  require('./cases/serve.cjs'),
+  require('./cases/headers.cjs'),
+  require('./cases/basic-auth.cjs'),
+  require('./cases/bearer-auth.cjs'),
+  require('./cases/whitelist-allow.cjs'),
+  require('./cases/whitelist-deny.cjs'),
+  require('./cases/https-only.cjs'),
+  require('./cases/tcp.cjs'),
+  require('./cases/udp.cjs'),
+  require('./cases/config-roundtrip.cjs'),
+  require('./cases/debugger-ws.cjs'),
+];
+
+async function main() {
+  process.stdout.write(`Pinggy E2E suite\n`);
+  process.stdout.write(`  binary: ${binaryPath}\n`);
+  process.stdout.write(`  workdir: ${workDir}\n`);
+  process.stdout.write(`  platform: ${process.platform} ${process.arch}\n`);
+
+  let failed = false;
+  for (const c of cases) {
+    try {
+      await runCase(c.name, c.run);
+    } catch {
+      failed = true;
+      break;
+    }
+  }
+
+  process.stdout.write(`\n=== summary ===\n`);
+  for (const r of getResults()) {
+    process.stdout.write(`  ${r.status}  ${r.name}\n`);
+  }
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('runner crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
- Implemented test cases for basic authentication, bearer authentication, configuration roundtrip, and whitelist rules.
- Added echo servers for HTTP, TCP, and UDP to facilitate testing.